### PR TITLE
feature: track multiple components separately in render counter

### DIFF
--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -12,15 +12,23 @@ counter.style.cssText = `
   font-size: 14px;
   z-index: 999999;
   box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+  max-height: 150px;
+  overflow: auto;
 `;
 document.body.prepend(counter);
 
-// Get component name from script tag
+//? Global store for tracking render counts per instance
+const renderCounts = {};
+
+//? global hook object to track component tree updates
+const devTools = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+
+//? Get component name from script tag
 const componentName = document.currentScript.dataset.componentName;
 
-// Wait for React DevTools hook
+//? Wait for React DevTools hook
 const checkReact = setInterval(() => {
-  if (window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+  if (devTools) {
     clearInterval(checkReact);
     startTracking();
     return;
@@ -30,70 +38,89 @@ const checkReact = setInterval(() => {
 }, 100);
 
 function startTracking() {
-  let renderCount = 0;
-  const devTools = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-  let previousProps = null;
-  let previousState = null;
+  counter.innerHTML = `Counter tracker for <b>${componentName}</b> is ready. Please start rendering!`;
 
   const originalOnCommitFiberRoot = devTools.onCommitFiberRoot;
 
   devTools.onCommitFiberRoot = (...args) => {
     originalOnCommitFiberRoot?.(...args);
 
-    // New: Only check when components actually update
+    //? New: Only check when components actually update
     const fiberRoot = args[1];
     checkForUpdates(fiberRoot.current);
   };
+}
 
-  function checkForUpdates(fiber) {
-    if (!fiber) return;
+function checkForUpdates(fiber) {
+  if (!fiber) return;
 
-    const name = fiber.type?.displayName || fiber.type?.name;
-    if (name === componentName) {
-      const currentProps = fiber.memoizedProps;
-      const currentState = fiber.memoizedState;
+  const name = fiber.type?.displayName || fiber.type?.name;
 
-      if (
-        !shallowEqual(previousProps, currentProps) ||
-        !shallowEqual(previousState, currentState)
-      ) {
-        renderCount++;
-        counter.textContent = `${componentName}: ${renderCount} renders`;
-      }
+  if (name === componentName) {
+    //? Generate a unique ID for each instance
+    const instanceKey =
+      fiber.stateNode?._debugOwner?._debugID ||
+      fiber.alternate?._debugID ||
+      Math.random().toString(36).slice(2);
 
-      previousProps = currentProps;
-      previousState = currentState;
+    if (!renderCounts[instanceKey]) {
+      renderCounts[instanceKey] = {
+        count: 0,
+        prevProps: null,
+        prevState: null,
+      };
     }
 
-    checkForUpdates(fiber.child);
-    checkForUpdates(fiber.sibling);
+    const instance = renderCounts[instanceKey];
+    const currentProps = fiber.memoizedProps;
+    const currentState = fiber.memoizedState;
+
+    if (
+      !shallowEqual(instance.prevProps, currentProps) ||
+      !shallowEqual(instance.prevState, currentState)
+    ) {
+      instance.count++;
+      instance.prevProps = currentProps;
+      instance.prevState = currentState;
+    }
+
+    updateUI();
   }
 
-  // Simple shallow comparison
-  function shallowEqual(objA, objB) {
-    if (objA === objB) return true;
-    if (
-      typeof objA !== "object" ||
-      objA === null ||
-      typeof objB !== "object" ||
-      objB === null
-    ) {
+  checkForUpdates(fiber.child);
+  checkForUpdates(fiber.sibling);
+}
+
+function shallowEqual(objA, objB) {
+  if (objA === objB) return true;
+  if (
+    typeof objA !== "object" ||
+    objA === null ||
+    typeof objB !== "object" ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) return false;
+
+  for (let i = 0; i < keysA.length; i++) {
+    if (objA[keysA[i]] !== objB[keysA[i]]) {
       return false;
     }
-
-    const keysA = Object.keys(objA);
-    const keysB = Object.keys(objB);
-
-    if (keysA.length !== keysB.length) return false;
-
-    for (let i = 0; i < keysA.length; i++) {
-      if (objA[keysA[i]] !== objB[keysA[i]]) {
-        return false;
-      }
-    }
-
-    return true;
   }
 
-  counter.textContent = `${componentName}: 0 renders`;
+  return true;
+}
+
+function updateUI() {
+  counter.innerHTML = Object.entries(renderCounts)
+    .map(
+      ([_, instance], index) =>
+        `${componentName} ${index + 1}: ${instance.count} renders`
+    )
+    .join("<br>");
 }


### PR DESCRIPTION
This update fixes an issue where the render counter incorrectly increments for all instances of a component together. Now, each instance of a tracked component maintains its own separate render count.
Changes Made:

- Identifies each component instance separately instead of grouping all instances together.
- Uses unique instance keys to track renders per instance.
- Ensures the counter only increments when props or state change for each specific instance.
- Improves UI to display counts for multiple instances individually.

